### PR TITLE
Add chefspec to generators

### DIFF
--- a/lib/chef-dk/command/generator_commands/app.rb
+++ b/lib/chef-dk/command/generator_commands/app.rb
@@ -57,10 +57,15 @@ module ChefDK
           Generator.add_attr_to_context(:app_name, app_name)
           Generator.add_attr_to_context(:cookbook_root, cookbook_root)
           Generator.add_attr_to_context(:cookbook_name, cookbook_name)
+          Generator.add_attr_to_context(:recipe_name, recipe_name)
         end
 
         def recipe
           "app"
+        end
+
+        def recipe_name
+          "default"
         end
 
         def app_name

--- a/lib/chef-dk/command/generator_commands/cookbook.rb
+++ b/lib/chef-dk/command/generator_commands/cookbook.rb
@@ -59,10 +59,15 @@ module ChefDK
           Generator.add_attr_to_context(:skip_git_init, cookbook_path_in_git_repo?)
           Generator.add_attr_to_context(:cookbook_root, cookbook_root)
           Generator.add_attr_to_context(:cookbook_name, cookbook_name)
+          Generator.add_attr_to_context(:recipe_name, recipe_name)
         end
 
         def recipe
           "cookbook"
+        end
+
+        def recipe_name
+          "default"
         end
 
         def cookbook_name

--- a/lib/chef-dk/command/generator_commands/cookbook_code_file.rb
+++ b/lib/chef-dk/command/generator_commands/cookbook_code_file.rb
@@ -58,6 +58,7 @@ module ChefDK
           Generator.add_attr_to_context(:cookbook_root, cookbook_root)
           Generator.add_attr_to_context(:cookbook_name, cookbook_name)
           Generator.add_attr_to_context(:new_file_basename, new_file_basename)
+          Generator.add_attr_to_context(:recipe_name, new_file_basename)
         end
 
         def cookbook_root

--- a/lib/chef-dk/skeletons/code_generator/files/default/converge_spec.rb
+++ b/lib/chef-dk/skeletons/code_generator/files/default/converge_spec.rb
@@ -1,9 +1,0 @@
-require 'spec_helper'
-
-describe 'demo::default' do
-  let(:chef_run) { ChefSpec::Runner.new.converge("demo::default") }
-
-  it "converges successfully" do
-    chef_run # This should not raise an error
-  end
-end

--- a/lib/chef-dk/skeletons/code_generator/files/default/spec_helper.rb
+++ b/lib/chef-dk/skeletons/code_generator/files/default/spec_helper.rb
@@ -1,8 +1,2 @@
 require 'chefspec'
-
-current_dir = File.dirname(__FILE__)
-
-RSpec.configure do |config|
-  # Point to the cookbooks directory
-  config.cookbook_path = File.join(current_dir, '../cookbooks')
-end
+require 'chefspec/berkshelf'

--- a/lib/chef-dk/skeletons/code_generator/recipes/app.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/app.rb
@@ -51,6 +51,23 @@ template "#{cookbook_dir}/recipes/default.rb" do
   helpers(ChefDK::Generator::TemplateHelper)
 end
 
+# Chefspec
+directory "#{cookbook_dir}/spec/unit/recipes" do
+  recursive true
+end
+
+cookbook_file "#{cookbook_dir}/spec/spec_helper.rb" do
+  action :create_if_missing
+end
+
+template "#{cookbook_dir}/spec/unit/recipes/default_spec.rb" do
+  source "recipe_spec.rb.erb"
+  helpers(ChefDK::Generator::TemplateHelper)
+  action :create_if_missing
+  variables(
+  :recipe_name => 'default')
+end
+
 # git
 if context.have_git
 

--- a/lib/chef-dk/skeletons/code_generator/recipes/app.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/app.rb
@@ -49,8 +49,6 @@ directory "#{cookbook_dir}/recipes"
 template "#{cookbook_dir}/recipes/default.rb" do
   source "recipe.rb.erb"
   helpers(ChefDK::Generator::TemplateHelper)
-  variables(
-    :recipe_name => 'default')
 end
 
 # Chefspec
@@ -66,8 +64,6 @@ template "#{cookbook_dir}/spec/unit/recipes/default_spec.rb" do
   source "recipe_spec.rb.erb"
   helpers(ChefDK::Generator::TemplateHelper)
   action :create_if_missing
-  variables(
-  :recipe_name => 'default')
 end
 
 # git

--- a/lib/chef-dk/skeletons/code_generator/recipes/app.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/app.rb
@@ -47,8 +47,10 @@ cookbook_file "#{cookbook_dir}/Berksfile"
 directory "#{cookbook_dir}/recipes"
 
 template "#{cookbook_dir}/recipes/default.rb" do
-  source "default_recipe.rb.erb"
+  source "recipe.rb.erb"
   helpers(ChefDK::Generator::TemplateHelper)
+  variables(
+    :recipe_name => 'default')
 end
 
 # Chefspec

--- a/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
@@ -32,6 +32,24 @@ template "#{cookbook_dir}/.kitchen.yml" do
   action :create_if_missing
 end
 
+# Chefspec
+
+directory "#{cookbook_dir}/spec/unit/recipes" do
+  recursive true
+end
+
+cookbook_file "#{cookbook_dir}/spec/spec_helper.rb" do
+  action :create_if_missing
+end
+
+template "#{cookbook_dir}/spec/unit/recipes/default_spec.rb" do
+  source "recipe_spec.rb.erb"
+  helpers(ChefDK::Generator::TemplateHelper)
+  action :create_if_missing
+  variables(
+  :recipe_name => 'default')
+end
+
 # Recipes
 
 directory "#{cookbook_dir}/recipes"

--- a/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
@@ -55,9 +55,11 @@ end
 directory "#{cookbook_dir}/recipes"
 
 template "#{cookbook_dir}/recipes/default.rb" do
-  source "default_recipe.rb.erb"
+  source "recipe.rb.erb"
   helpers(ChefDK::Generator::TemplateHelper)
   action :create_if_missing
+  variables(
+  :recipe_name => 'default')
 end
 
 # git

--- a/lib/chef-dk/skeletons/code_generator/recipes/recipe.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/recipe.rb
@@ -17,8 +17,6 @@ end
 template spec_path do
   source "recipe_spec.rb.erb"
   helpers(ChefDK::Generator::TemplateHelper)
-  variables(
-    :recipe_name => context.new_file_basename)
   action :create_if_missing
 end
 
@@ -26,6 +24,4 @@ end
 template recipe_path do
   source "recipe.rb.erb"
   helpers(ChefDK::Generator::TemplateHelper)
-  variables(
-    :recipe_name => context.new_file_basename)
 end

--- a/lib/chef-dk/skeletons/code_generator/recipes/recipe.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/recipe.rb
@@ -19,6 +19,7 @@ template spec_path do
   helpers(ChefDK::Generator::TemplateHelper)
   variables(
     :recipe_name => context.new_file_basename)
+  action :create_if_missing
 end
 
 # Recipe

--- a/lib/chef-dk/skeletons/code_generator/recipes/recipe.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/recipe.rb
@@ -2,8 +2,29 @@
 context = ChefDK::Generator.context
 cookbook_dir = File.join(context.cookbook_root, context.cookbook_name)
 recipe_path = File.join(cookbook_dir, "recipes", "#{context.new_file_basename}.rb")
+spec_helper_path = File.join(cookbook_dir, "spec", "spec_helper.rb")
+spec_path = File.join(cookbook_dir, "spec", "unit", "recipes", "#{context.new_file_basename}_spec.rb")
 
+# Chefspec
+directory "#{cookbook_dir}/spec/unit/recipes" do
+  recursive true
+end
+
+cookbook_file spec_helper_path do
+  action :create_if_missing
+end
+
+template spec_path do
+  source "recipe_spec.rb.erb"
+  helpers(ChefDK::Generator::TemplateHelper)
+  variables(
+    :recipe_name => context.new_file_basename)
+end
+
+# Recipe
 template recipe_path do
   source "recipe.rb.erb"
   helpers(ChefDK::Generator::TemplateHelper)
+  variables(
+    :recipe_name => context.new_file_basename)
 end

--- a/lib/chef-dk/skeletons/code_generator/templates/default/default_recipe.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/default_recipe.rb.erb
@@ -1,5 +1,0 @@
-#
-# Cookbook Name:: <%= cookbook_name %>
-# Recipe:: default
-#
-<%= license_description('#') %>

--- a/lib/chef-dk/skeletons/code_generator/templates/default/recipe.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/recipe.rb.erb
@@ -1,5 +1,5 @@
 #
 # Cookbook Name:: <%= cookbook_name %>
-# Recipe:: <%= @recipe_name %>
+# Recipe:: <%= recipe_name %>
 #
 <%= license_description('#') %>

--- a/lib/chef-dk/skeletons/code_generator/templates/default/recipe.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/recipe.rb.erb
@@ -1,0 +1,5 @@
+#
+# Cookbook Name:: <%= cookbook_name %>
+# Recipe:: <%= @recipe_name %>
+#
+<%= license_description('#') %>

--- a/lib/chef-dk/skeletons/code_generator/templates/default/recipe_spec.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/recipe_spec.rb.erb
@@ -6,7 +6,7 @@
 
 require 'spec_helper'
 
-describe '<%= cookbook_name %>::<%= @recipe_name %>' do
+describe '<%= cookbook_name %>::<%= recipe_name %>' do
 
   context 'When all attributes are default, on an unspecified platform' do
 

--- a/lib/chef-dk/skeletons/code_generator/templates/default/recipe_spec.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/recipe_spec.rb.erb
@@ -1,0 +1,23 @@
+#
+# Cookbook Name:: <%= cookbook_name %>
+# Spec:: default
+#
+<%= license_description('#') %>
+
+require 'spec_helper'
+
+describe '<%= cookbook_name %>::<%= @recipe_name %>' do
+
+  context 'When all attributes are default, on an unspecified platform' do
+
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new
+      runner.converge(described_recipe)
+    end
+
+    it 'converges successfully' do
+      chef_run # This should not raise an error
+    end
+
+  end
+end

--- a/spec/shared/a_file_generator.rb
+++ b/spec/shared/a_file_generator.rb
@@ -63,6 +63,7 @@ shared_examples_for "a file generator" do
         expect(generator_context.cookbook_root).to eq(expected_cookbook_root)
         expect(generator_context.cookbook_name).to eq(cookbook_name)
         expect(generator_context.new_file_basename).to eq(new_file_name)
+        expect(generator_context.recipe_name).to eq(new_file_name)
       end
     end
 

--- a/spec/unit/command/generator_commands/app_spec.rb
+++ b/spec/unit/command/generator_commands/app_spec.rb
@@ -72,6 +72,7 @@ describe ChefDK::Command::GeneratorCommands::App do
       expect(generator_context.app_name).to eq("new_app")
       expect(generator_context.cookbook_root).to eq(File.join(Dir.pwd, "new_app", "cookbooks"))
       expect(generator_context.cookbook_name).to eq("new_app")
+      expect(generator_context.recipe_name).to eq("default")
     end
 
     describe "generated files" do

--- a/spec/unit/command/generator_commands/app_spec.rb
+++ b/spec/unit/command/generator_commands/app_spec.rb
@@ -35,6 +35,11 @@ describe ChefDK::Command::GeneratorCommands::App do
       cookbooks/new_app/metadata.rb
       cookbooks/new_app/recipes
       cookbooks/new_app/recipes/default.rb
+      cookbooks/new_app/spec
+      cookbooks/new_app/spec/spec_helper.rb
+      cookbooks/new_app/spec/unit
+      cookbooks/new_app/spec/unit/recipes
+      cookbooks/new_app/spec/unit/recipes/default_spec.rb
     ]
   end
 
@@ -125,6 +130,15 @@ describe ChefDK::Command::GeneratorCommands::App do
           let(:line) { "# Cookbook Name:: new_app" }
         end
       end
+
+      describe "cookbooks/new_app/spec/unit/recipes/default_spec.rb" do
+        let(:file) { File.join(tempdir, "new_app", "cookbooks", "new_app", "spec", "unit", "recipes", "default_spec.rb") }
+
+        include_examples "a generated file", :cookbook_name do
+          let(:line) { "describe \'new_app::default\' do" }
+        end
+      end
+
     end
   end
 end

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -35,6 +35,11 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
       README.md
       recipes
       recipes/default.rb
+      spec
+      spec/spec_helper.rb
+      spec/unit
+      spec/unit/recipes
+      spec/unit/recipes/default_spec.rb
     ]
   end
 
@@ -152,6 +157,14 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
 
       include_examples "a generated file", :cookbook_name do
         let(:line) { "# Cookbook Name:: new_cookbook" }
+      end
+    end
+
+    describe "spec/unit/recipes/default_spec.rb" do
+      let(:file) { File.join(tempdir, "new_cookbook", "spec", "unit", "recipes", "default_spec.rb") }
+
+      include_examples "a generated file", :cookbook_name do
+        let(:line) { "describe \'new_cookbook::default\' do" }
       end
     end
 

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -102,6 +102,7 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
       cookbook_generator.setup_context
       expect(generator_context.cookbook_root).to eq(Dir.pwd)
       expect(generator_context.cookbook_name).to eq("new_cookbook")
+      expect(generator_context.recipe_name).to eq("default")
     end
 
     it "creates a new cookbook" do

--- a/spec/unit/command/generator_commands/recipe_spec.rb
+++ b/spec/unit/command/generator_commands/recipe_spec.rb
@@ -24,9 +24,11 @@ describe ChefDK::Command::GeneratorCommands::Recipe do
   include_examples "a file generator" do
 
     let(:generator_name) { "recipe" }
-    let(:generated_files) { [ "recipes/new_recipe.rb" ] }
+    let(:generated_files) { [ "recipes/new_recipe.rb",
+                              "spec/spec_helper.rb",
+                              "spec/unit/recipes/new_recipe_spec.rb" ] }
     let(:new_file_name) { "new_recipe" }
 
   end
-end
 
+end


### PR DESCRIPTION
Any recipe generated by `chef generate` should now also automatically have a corresponding spec file template generated in spec/unit/recipes. In addition, a spec/spec_helper.rb file will be created if one does not currently exist.

I also consolidated the redundant template/recipe.rb and template/default_recipe.rb files for easier maintenance.