### PR TITLE
Added serverspec to cookbook & app generators

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/files/default/serverspec_spec_helper.rb
+++ b/lib/chef-dk/skeletons/code_generator/files/default/serverspec_spec_helper.rb
@@ -1,0 +1,3 @@
+require 'serverspec'
+
+set :backend, :exec

--- a/lib/chef-dk/skeletons/code_generator/recipes/app.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/app.rb
@@ -18,6 +18,21 @@ template "#{app_dir}/.kitchen.yml" do
   helpers(ChefDK::Generator::TemplateHelper)
 end
 
+directory "#{app_dir}/test/integration/default/serverspec" do
+  recursive true
+end
+
+cookbook_file "#{app_dir}/test/integration/default/serverspec/spec_helper.rb" do
+  source 'serverspec_spec_helper.rb'
+  action :create_if_missing
+end
+
+template "#{app_dir}/test/integration/default/serverspec/default_spec.rb" do
+  source 'serverspec_default_spec.rb.erb'
+  helpers(ChefDK::Generator::TemplateHelper)
+  action :create_if_missing
+end
+
 # README
 template "#{app_dir}/README.md" do
   helpers(ChefDK::Generator::TemplateHelper)

--- a/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
@@ -32,6 +32,21 @@ template "#{cookbook_dir}/.kitchen.yml" do
   action :create_if_missing
 end
 
+directory "#{cookbook_dir}/test/integration/default/serverspec" do
+  recursive true
+end
+
+cookbook_file "#{cookbook_dir}/test/integration/default/serverspec/spec_helper.rb" do
+  source 'serverspec_spec_helper.rb'
+  action :create_if_missing
+end
+
+template "#{cookbook_dir}/test/integration/default/serverspec/default_spec.rb" do
+  source 'serverspec_default_spec.rb.erb'
+  helpers(ChefDK::Generator::TemplateHelper)
+  action :create_if_missing
+end
+
 # Recipes
 
 directory "#{cookbook_dir}/recipes"

--- a/lib/chef-dk/skeletons/code_generator/templates/default/serverspec_default_spec.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/serverspec_default_spec.rb.erb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe '<%= cookbook_name %>::default' do
+
+  # Serverspec examples can be found at
+  # http://serverspec.org/resource_types.html
+  
+  it 'does something' do
+    skip 'Replace this with meaningful tests'
+  end
+
+end

--- a/spec/unit/command/generator_commands/app_spec.rb
+++ b/spec/unit/command/generator_commands/app_spec.rb
@@ -29,6 +29,12 @@ describe ChefDK::Command::GeneratorCommands::App do
     %w[
       .gitignore
       .kitchen.yml
+      test
+      test/integration
+      test/integration/default
+      test/integration/default/serverspec
+      test/integration/default/serverspec/default_spec.rb
+      test/integration/default/serverspec/spec_helper.rb
       README.md
       cookbooks/new_app/Berksfile
       cookbooks/new_app/chefignore
@@ -107,6 +113,14 @@ describe ChefDK::Command::GeneratorCommands::App do
 
         include_examples "a generated file", :cookbook_name do
           let(:line) { /\s*- recipe\[new_app::default\]/ }
+        end
+      end
+
+      describe "test/integration/default/serverspec/default_spec.rb" do
+        let(:file) { File.join(tempdir, "new_app", "test", "integration", "default", "serverspec", "default_spec.rb") }
+
+        include_examples "a generated file", :cookbook_name do
+          let(:line) { "describe 'new_app::default' do" }
         end
       end
 

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -29,6 +29,12 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
     %w[
       .gitignore
       .kitchen.yml
+      test
+      test/integration
+      test/integration/default
+      test/integration/default/serverspec
+      test/integration/default/serverspec/default_spec.rb
+      test/integration/default/serverspec/spec_helper.rb
       Berksfile
       chefignore
       metadata.rb
@@ -136,6 +142,14 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
 
       include_examples "a generated file", :cookbook_name do
         let(:line) { /\s*- recipe\[new_cookbook::default\]/ }
+      end
+    end
+
+    describe "test/integration/default/serverspec/default_spec.rb" do
+      let(:file) { File.join(tempdir, "new_cookbook", "test", "integration", "default", "serverspec", "default_spec.rb") }
+
+      include_examples "a generated file", :cookbook_name do
+        let(:line) { "describe 'new_cookbook::default' do" }
       end
     end
 


### PR DESCRIPTION
chef generate will now automatically create a serverspec test for the default suite when it generates a .kitchen.yml.
- Updated app_spec.rb to check for serverspec suite
- Updated cookbook_spec.rb to check for serverspec suite
- Updated app.rb recipe to generate serverspec test for default suite
- Updated cookbook.rb recipe to generate serverspec test for default suite
- Added file for serverspec_spec_helper.rb
- Added template for serverspec_default_spec.rb