### PR TITLE
Support cookbooks with only metadata.json

### DIFF
--- a/lib/chef-dk/cookbook_metadata.rb
+++ b/lib/chef-dk/cookbook_metadata.rb
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+require 'chef-dk/exceptions'
 require 'chef/cookbook/metadata'
 
 module ChefDK
@@ -24,8 +25,16 @@ module ChefDK
   class CookbookMetadata < Chef::Cookbook::Metadata
 
     def self.from_path(path)
+      metadata_json_path = File.join(path, "metadata.json")
       metadata_rb_path = File.join(path, "metadata.rb")
-      new.tap { |m| m.from_file(metadata_rb_path) }
+
+      if File.exist?(metadata_json_path)
+        new.tap { |m| m.from_json(File.read(metadata_json_path)) }
+      elsif File.exist?(metadata_rb_path)
+        new.tap { |m| m.from_file(metadata_rb_path) }
+      else
+        raise MalformedCookbook, "Cookbook at #{path} has neither metadata.json or metadata.rb"
+      end
     end
 
     def cookbook_name

--- a/spec/unit/cookbook_metadata_spec.rb
+++ b/spec/unit/cookbook_metadata_spec.rb
@@ -40,21 +40,57 @@ describe ChefDK::CookbookMetadata do
 
   describe "when a cookbook is loaded" do
 
-    let(:cookbook_root) { File.join(fixtures_path, 'example_cookbook') }
 
     let(:cookbook) { described_class.from_path(cookbook_root) }
 
-    it "has a name" do
-      expect(cookbook.name).to eq("example_cookbook")
-      expect(cookbook.cookbook_name).to eq("example_cookbook")
+    context "and the cookbook has only a metadata.rb" do
+
+      let(:cookbook_root) { File.join(fixtures_path, 'example_cookbook') }
+
+      it "has a name" do
+        expect(cookbook.name).to eq("example_cookbook")
+        expect(cookbook.cookbook_name).to eq("example_cookbook")
+      end
+
+      it "has a version" do
+        expect(cookbook.version).to eq("0.1.0")
+      end
+
+      it "has a map of dependencies" do
+        expect(cookbook.dependencies).to eq({})
+      end
+
     end
 
-    it "has a version" do
-      expect(cookbook.version).to eq("0.1.0")
+    context "and the cookbook has only a metadata.json" do
+
+      let(:cookbook_root) { File.join(fixtures_path, 'example_cookbook_metadata_json_only') }
+
+      it "has a name" do
+        expect(cookbook.name).to eq("example_cookbook")
+        expect(cookbook.cookbook_name).to eq("example_cookbook")
+      end
+
+      it "has a version" do
+        expect(cookbook.version).to eq("0.1.0")
+      end
+
+      it "has a map of dependencies" do
+        expect(cookbook.dependencies).to eq({})
+      end
+
     end
 
-    it "has a map of dependencies" do
-      expect(cookbook.dependencies).to eq({})
+    context "and the cookbook has no metadata" do
+
+      let(:cookbook_root) { File.join(fixtures_path, 'example_cookbook_no_metadata') }
+
+      it "raises a MalformedCookbook error" do
+        msg = "Cookbook at #{cookbook_root} has neither metadata.json or metadata.rb"
+
+        expect { cookbook }.to raise_error(ChefDK::MalformedCookbook, msg)
+      end
+
     end
 
   end

--- a/spec/unit/fixtures/example_cookbook_metadata_json_only/.gitignore
+++ b/spec/unit/fixtures/example_cookbook_metadata_json_only/.gitignore
@@ -1,0 +1,17 @@
+.vagrant
+Berksfile.lock
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+/cookbooks
+
+# Bundler
+Gemfile.lock
+bin/*
+.bundle/*
+
+.kitchen/
+.kitchen.local.yml

--- a/spec/unit/fixtures/example_cookbook_metadata_json_only/.kitchen.yml
+++ b/spec/unit/fixtures/example_cookbook_metadata_json_only/.kitchen.yml
@@ -1,0 +1,16 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_solo
+
+platforms:
+  - name: ubuntu-12.04
+  - name: centos-6.4
+
+suites:
+  - name: default
+    run_list:
+      - recipe[bar::default]
+    attributes:

--- a/spec/unit/fixtures/example_cookbook_metadata_json_only/Berksfile
+++ b/spec/unit/fixtures/example_cookbook_metadata_json_only/Berksfile
@@ -1,0 +1,3 @@
+source "https://supermarket.getchef.com"
+
+metadata

--- a/spec/unit/fixtures/example_cookbook_metadata_json_only/README.md
+++ b/spec/unit/fixtures/example_cookbook_metadata_json_only/README.md
@@ -1,0 +1,4 @@
+# bar-cookbook
+
+TODO: Enter the cookbook description here.
+

--- a/spec/unit/fixtures/example_cookbook_metadata_json_only/chefignore
+++ b/spec/unit/fixtures/example_cookbook_metadata_json_only/chefignore
@@ -1,0 +1,96 @@
+# Put files/directories that should be ignored in this file when uploading
+# or sharing to the community site.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+Guardfile
+Procfile
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+Berksfile
+Berksfile.lock
+cookbooks/*
+tmp
+
+# Cookbooks #
+#############
+CONTRIBUTING
+CHANGELOG*
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile
+
+# Travis #
+##########
+.travis.yml

--- a/spec/unit/fixtures/example_cookbook_metadata_json_only/metadata.json
+++ b/spec/unit/fixtures/example_cookbook_metadata_json_only/metadata.json
@@ -1,0 +1,5 @@
+{
+  "name": "example_cookbook",
+  "version": "0.1.0"
+}
+

--- a/spec/unit/fixtures/example_cookbook_metadata_json_only/recipes/default.rb
+++ b/spec/unit/fixtures/example_cookbook_metadata_json_only/recipes/default.rb
@@ -1,0 +1,8 @@
+#
+# Cookbook Name:: example_cookbook
+# Recipe:: default
+#
+# Copyright (C) 2014 
+#
+# 
+#

--- a/spec/unit/fixtures/example_cookbook_no_metadata/.gitignore
+++ b/spec/unit/fixtures/example_cookbook_no_metadata/.gitignore
@@ -1,0 +1,17 @@
+.vagrant
+Berksfile.lock
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+/cookbooks
+
+# Bundler
+Gemfile.lock
+bin/*
+.bundle/*
+
+.kitchen/
+.kitchen.local.yml

--- a/spec/unit/fixtures/example_cookbook_no_metadata/.kitchen.yml
+++ b/spec/unit/fixtures/example_cookbook_no_metadata/.kitchen.yml
@@ -1,0 +1,16 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_solo
+
+platforms:
+  - name: ubuntu-12.04
+  - name: centos-6.4
+
+suites:
+  - name: default
+    run_list:
+      - recipe[bar::default]
+    attributes:

--- a/spec/unit/fixtures/example_cookbook_no_metadata/Berksfile
+++ b/spec/unit/fixtures/example_cookbook_no_metadata/Berksfile
@@ -1,0 +1,3 @@
+source "https://supermarket.getchef.com"
+
+metadata

--- a/spec/unit/fixtures/example_cookbook_no_metadata/README.md
+++ b/spec/unit/fixtures/example_cookbook_no_metadata/README.md
@@ -1,0 +1,4 @@
+# bar-cookbook
+
+TODO: Enter the cookbook description here.
+

--- a/spec/unit/fixtures/example_cookbook_no_metadata/chefignore
+++ b/spec/unit/fixtures/example_cookbook_no_metadata/chefignore
@@ -1,0 +1,96 @@
+# Put files/directories that should be ignored in this file when uploading
+# or sharing to the community site.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+Guardfile
+Procfile
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+Berksfile
+Berksfile.lock
+cookbooks/*
+tmp
+
+# Cookbooks #
+#############
+CONTRIBUTING
+CHANGELOG*
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile
+
+# Travis #
+##########
+.travis.yml

--- a/spec/unit/fixtures/example_cookbook_no_metadata/recipes/default.rb
+++ b/spec/unit/fixtures/example_cookbook_no_metadata/recipes/default.rb
@@ -1,0 +1,8 @@
+#
+# Cookbook Name:: example_cookbook
+# Recipe:: default
+#
+# Copyright (C) 2014 
+#
+# 
+#


### PR DESCRIPTION
The latest `apt` cookbook doesn't contain a `metadata.rb`, only `metadata.json`. This patch updates the metadata loading code to prefer `metadata.json`, fall back to `metadata.rb`, and explicitly error if neither are found.